### PR TITLE
Fix header menu so that the underline doesn't push content down

### DIFF
--- a/style.css
+++ b/style.css
@@ -27,11 +27,13 @@ body {
   border-right: none;
 }
 .nav li a {
-  margin-right: 25px;
-  margin-left: 25px;
+  margin: 5px 25px;
+  padding-top: 10px;
+  padding-bottom: 10px;
   color: black;
 }
 .nav li a:hover {
+  margin-bottom: 0px;
   border-bottom: 5px solid lightgray;
 }
 


### PR DESCRIPTION
Fixes the following issue:
![menu-push](https://user-images.githubusercontent.com/4037224/79031060-5ae61780-7b6a-11ea-98e4-9c5035823f53.gif)

Result:
![menu-not-push](https://user-images.githubusercontent.com/4037224/79031077-77824f80-7b6a-11ea-9eab-901e98472f3e.gif)
