### PR TITLE
Increase Build Speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
 before_script: bundle exec jekyll build
-script: bundle exec jekyll build && bundle exec htmlproofer --url-ignore "/cslabs" ./_site --check-html
+script: bundle exec htmlproofer --url-ignore "/cslabs" ./_site --check-html

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,4 @@ jobs:
     - stage: build
       script: bundle exec jekyll build
     - stage: testlinks
-      script: bundle exec jekyll build && bundle exec htmlproofer ./_site --check-html
-    
+      script: bundle exec jekyll build && bundle exec htmlproofer --url-ignore "/cslabs" ./_site --check-html

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,5 @@ addons:
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
-jobs:
-  include:
-    - stage: build
-      script: bundle exec jekyll build
-    - stage: testlinks
-      script: bundle exec jekyll build && bundle exec htmlproofer --url-ignore "/cslabs" ./_site --check-html
+before_script: bundle exec jekyll build
+script: bundle exec jekyll build && bundle exec htmlproofer --url-ignore "/cslabs" ./_site --check-html


### PR DESCRIPTION
Fixes https://github.com/ius-csg/csghomepage/issues/27

Combines the two stages into one to prevent a 2nd VM from booting.

This also contains changes to fix the build as well by adding an ignore for /cslabs link because the linter cannot verify that it exists since it lives in another repository.