### PR TITLE
Correct buttons on mobile 

### DIFF
--- a/style.css
+++ b/style.css
@@ -191,8 +191,7 @@ index-calendar {
   border-radius: 5px;
 }
 .subtitle {
-  display: flex;
-  justify-content: center;
+  text-align: center;
 }
 /************************** CAROUSEL **********************************/
 .carousel-caption {


### PR DESCRIPTION
This PR stops subtitles from being flexed on mobile, which causes buttons to overlap the screen's edge. 

Before:
![image](https://user-images.githubusercontent.com/15039983/132967080-343d4421-5d33-4c57-a356-180c0f787cf8.png)

After:
![image](https://user-images.githubusercontent.com/15039983/132967088-e2c9d671-2652-47b2-b515-1f388e5e1fab.png)
